### PR TITLE
Fix redirection for mobalytics profile page

### DIFF
--- a/chrome/background.js
+++ b/chrome/background.js
@@ -27,9 +27,17 @@ const RULES = [
     script: 'content_buildguide.js'
   },
   {
-    match: url => url.includes('mobalytics.gg/poe/builds/') &&
-                  // exclude the directory index page itself
-                  url.replace('mobalytics.gg/poe/builds', '').replace(/\/$/, '').length > 0,
+    match: url => {
+      if (!url.includes('mobalytics.gg')) return false;
+      // /poe/builds/[slug] — exclude bare /poe/builds index
+      if (url.includes('mobalytics.gg/poe/builds/')) {
+        const after = url.split('mobalytics.gg/poe/builds/')[1] || '';
+        const slug = after.split(/[?#]/)[0].replace(/\/$/, '');
+        if (slug.length > 0) return true;
+      }
+      // /poe/profile/[user]/builds/[slug]
+      return /mobalytics\.gg\/poe\/profile\/[^/]+\/builds\/[^/?#]+/.test(url);
+    },
     script: 'content_mobalytics.js'
   }
 ];

--- a/chrome/content_mobalytics.js
+++ b/chrome/content_mobalytics.js
@@ -7,12 +7,20 @@
 
   const POB_CODE_REGEX = /^[A-Za-z0-9+/\-_]{80,}={0,2}$/;
 
-  // Only activate on specific build pages, not the directory index
+  // Only activate on specific build pages, not directory indexes
   function isBuildPage(url) {
     const path = url.replace(/https?:\/\/[^/]+/, '').replace(/\/$/, '');
     const parts = path.split('/').filter(Boolean);
-    // Must be /poe/builds/[slug] with a non-empty slug
-    return parts[0] === 'poe' && parts[1] === 'builds' && parts.length >= 3 && parts[2] !== '';
+    // /poe/builds/[slug]
+    if (parts[0] === 'poe' && parts[1] === 'builds' && parts.length >= 3 && parts[2] !== '') {
+      return true;
+    }
+    // /poe/profile/[user]/builds/[slug] e.g. .../profile/bigdaddygaming/builds/endgame-...
+    if (parts[0] === 'poe' && parts[1] === 'profile' && parts.length >= 5 &&
+        parts[3] === 'builds' && parts[4] !== '') {
+      return true;
+    }
+    return false;
   }
 
 

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "PathToPobb.in",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Automatically redirects Path of Exile build links from Maxroll and Mobalytics to pobb.in \u2014 code pre-filled, submitted instantly.",
   "permissions": [
     "storage",

--- a/firefox/content_mobalytics.js
+++ b/firefox/content_mobalytics.js
@@ -26,8 +26,16 @@
   let detecting = false;
 
   function isBuildPage(url) {
-    const path = url.replace(/https?:\/\/mobalytics\.gg/, '').replace(/\/$/, '');
-    return path.startsWith('/poe/builds/') && path.split('/').length >= 4 && path.split('/')[3] !== '';
+    const path = url.replace(/https?:\/\/[^/]+/, '').replace(/\/$/, '');
+    const parts = path.split('/').filter(Boolean);
+    if (parts[0] === 'poe' && parts[1] === 'builds' && parts.length >= 3 && parts[2] !== '') {
+      return true;
+    }
+    if (parts[0] === 'poe' && parts[1] === 'profile' && parts.length >= 5 &&
+        parts[3] === 'builds' && parts[4] !== '') {
+      return true;
+    }
+    return false;
   }
 
   function showOverlay() {

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "PathToPobb.in",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Automatically redirects Path of Exile build links from Maxroll and Mobalytics to pobb.in \u2014 code pre-filled, submitted instantly.",
   "browser_specific_settings": {
     "gecko": {


### PR DESCRIPTION
fix links such as https://mobalytics.gg/poe/profile/bigdaddygaming/builds/endgame-lightning-strike-armour-stacker
tested for firefox and works good